### PR TITLE
Add IRTerm as the base type of our (IR) logic

### DIFF
--- a/src/transpiler.rs
+++ b/src/transpiler.rs
@@ -19,7 +19,7 @@ use std::{collections::HashMap, sync::atomic::AtomicU32};
 
 use crate::{
     dockerfile::{Dockerfile, ResolvedParent},
-    logic::{self, Clause, Constant, Variable},
+    logic::{self, Clause},
     modusfile::Modusfile,
     sld,
 };
@@ -27,10 +27,9 @@ use crate::{
 pub fn prove_goal(
     mf: &Modusfile,
     goal: &Vec<logic::Literal>,
-) -> Result<Vec<sld::Proof<logic::Constant, logic::Variable>>, &'static str> {
+) -> Result<Vec<sld::Proof>, &'static str> {
     let max_depth = 20;
-    let clauses: Vec<Clause<logic::Constant, logic::Variable>> =
-        mf.0.iter().map(|mc| mc.into()).collect();
+    let clauses: Vec<Clause> = mf.0.iter().map(|mc| mc.into()).collect();
 
     let res = sld::sld(&clauses, goal, max_depth);
     match res {
@@ -49,17 +48,17 @@ static AVAILABLE_STAGE_INDEX: AtomicU32 = AtomicU32::new(0);
 
 fn proof_to_docker(
     rules: &Vec<Clause>,
-    proof: &sld::Proof<Constant, Variable>,
-    cache: &mut HashMap<sld::Goal<Constant, Variable>, ResolvedParent>,
-    goal: &sld::Goal<Constant, Variable>,
+    proof: &sld::Proof,
+    cache: &mut HashMap<sld::Goal, ResolvedParent>,
+    goal: &sld::Goal,
 ) -> ResolvedParent {
     todo!()
 }
 
 fn proofs_to_docker(
     rules: &Vec<Clause>,
-    proofs: &Vec<sld::Proof<Constant, Variable>>,
-    goal: &sld::Goal<Constant, Variable>,
+    proofs: &Vec<sld::Proof>,
+    goal: &sld::Goal,
 ) -> Dockerfile<ResolvedParent> {
     todo!()
 }

--- a/src/unification.rs
+++ b/src/unification.rs
@@ -18,60 +18,50 @@
 use std::collections::HashMap;
 
 use crate::logic;
-use crate::logic::{IRConstant, IRVariable};
-use logic::{Clause, Ground, Literal, Predicate, Term};
+use logic::{Clause, Ground, IRTerm, Literal, Predicate};
 
-pub type Substitution<C, V> = HashMap<V, Term<C, V>>;
+pub type Substitution<T = IRTerm> = HashMap<T, T>;
 
-impl<C: IRConstant, V: IRVariable> Ground for Substitution<C, V> {
+impl Ground for Substitution {
     fn is_ground(&self) -> bool {
-        let mut result = true;
-        for v in self.values() {
-            if !v.variables().is_empty() {
-                result = false
-            }
-        }
-        result
+        self.values().all(|v| v.is_ground())
     }
 }
 
-pub trait Substitute<C: IRConstant, V: IRVariable> {
+pub trait Substitute<T> {
     type Output;
 
-    fn substitute(&self, s: &Substitution<C, V>) -> Self::Output;
+    fn substitute(&self, s: &Substitution<T>) -> Self::Output;
 }
 
-pub trait Rename<V: IRVariable> {
-    fn rename(&self) -> V;
+pub trait Rename<T> {
+    fn rename(&self) -> T;
 }
 
-pub trait RenameWithSubstitution<C: IRConstant, V: IRVariable> {
+pub trait RenameWithSubstitution<T> {
     type Output;
 
-    fn rename(&self) -> (Self::Output, Substitution<C, V>);
+    fn rename_with_sub(&self) -> (Self::Output, Substitution<T>);
 }
 
-impl<C: IRConstant, V: IRVariable> Substitute<C, V> for Term<C, V> {
-    type Output = Term<C, V>;
-    fn substitute(&self, s: &Substitution<C, V>) -> Self::Output {
-        match &self {
-            Term::Variable(v) => s.get(v).unwrap_or(self).clone(),
-            _ => self.clone(),
-        }
+impl Substitute<IRTerm> for IRTerm {
+    type Output = IRTerm;
+    fn substitute(&self, s: &Substitution<IRTerm>) -> Self::Output {
+        s.get(self).unwrap_or(self).clone()
     }
 }
 
-impl<C: IRConstant, V: IRVariable> RenameWithSubstitution<C, V> for Term<C, V> {
-    type Output = Term<C, V>;
-    fn rename(&self) -> (Self::Output, Substitution<C, V>) {
-        let s: Substitution<C, V> = self
+impl RenameWithSubstitution<IRTerm> for IRTerm {
+    type Output = IRTerm;
+    fn rename_with_sub(&self) -> (Self::Output, Substitution<IRTerm>) {
+        let s: Substitution<IRTerm> = self
             .variables()
             .iter()
             .map(|r| {
-                [(r.clone(), Term::Variable(r.rename()))]
+                [(r.clone(), r.rename())]
                     .iter()
                     .cloned()
-                    .collect::<Substitution<C, V>>()
+                    .collect::<Substitution<IRTerm>>()
             })
             .reduce(|mut l, r| {
                 l.extend(r);
@@ -82,9 +72,9 @@ impl<C: IRConstant, V: IRVariable> RenameWithSubstitution<C, V> for Term<C, V> {
     }
 }
 
-impl<C: IRConstant, V: IRVariable> Substitute<C, V> for Literal<C, V> {
-    type Output = Literal<C, V>;
-    fn substitute(&self, s: &Substitution<C, V>) -> Self::Output {
+impl Substitute<IRTerm> for Literal<IRTerm> {
+    type Output = Literal;
+    fn substitute(&self, s: &Substitution<IRTerm>) -> Self::Output {
         Literal {
             atom: self.atom.clone(),
             args: self.args.iter().map(|t| t.substitute(s)).collect(),
@@ -92,17 +82,17 @@ impl<C: IRConstant, V: IRVariable> Substitute<C, V> for Literal<C, V> {
     }
 }
 
-impl<C: IRConstant, V: IRVariable> RenameWithSubstitution<C, V> for Literal<C, V> {
-    type Output = Literal<C, V>;
-    fn rename(&self) -> (Self::Output, Substitution<C, V>) {
-        let s: Substitution<C, V> = self
+impl RenameWithSubstitution<IRTerm> for Literal<IRTerm> {
+    type Output = Literal<IRTerm>;
+    fn rename_with_sub(&self) -> (Self::Output, Substitution<IRTerm>) {
+        let s: Substitution = self
             .variables()
             .iter()
             .map(|r| {
-                [(r.clone(), Term::Variable(r.rename()))]
+                [(r.clone(), r.rename())]
                     .iter()
                     .cloned()
-                    .collect::<Substitution<C, V>>()
+                    .collect::<Substitution>()
             })
             .reduce(|mut l, r| {
                 l.extend(r);
@@ -113,24 +103,24 @@ impl<C: IRConstant, V: IRVariable> RenameWithSubstitution<C, V> for Literal<C, V
     }
 }
 
-impl<C: IRConstant, V: IRVariable> Substitute<C, V> for Vec<Literal<C, V>> {
-    type Output = Vec<Literal<C, V>>;
-    fn substitute(&self, s: &Substitution<C, V>) -> Self::Output {
+impl Substitute<IRTerm> for Vec<Literal<IRTerm>> {
+    type Output = Vec<Literal<IRTerm>>;
+    fn substitute(&self, s: &Substitution<IRTerm>) -> Self::Output {
         self.iter().map(|l| l.substitute(s)).collect()
     }
 }
 
-impl<C: IRConstant, V: IRVariable> RenameWithSubstitution<C, V> for Vec<Literal<C, V>> {
-    type Output = Vec<Literal<C, V>>;
-    fn rename(&self) -> (Self::Output, Substitution<C, V>) {
-        let s: Substitution<C, V> = self
+impl RenameWithSubstitution<IRTerm> for Vec<Literal<IRTerm>> {
+    type Output = Vec<Literal<IRTerm>>;
+    fn rename_with_sub(&self) -> (Self::Output, Substitution<IRTerm>) {
+        let s: Substitution<IRTerm> = self
             .iter()
             .flat_map(|e| e.variables())
             .map(|r| {
-                [(r.clone(), Term::Variable(r.rename()))]
+                [(r.clone(), r.rename())]
                     .iter()
                     .cloned()
-                    .collect::<Substitution<C, V>>()
+                    .collect::<Substitution<IRTerm>>()
             })
             .reduce(|mut l, r| {
                 l.extend(r);
@@ -141,9 +131,9 @@ impl<C: IRConstant, V: IRVariable> RenameWithSubstitution<C, V> for Vec<Literal<
     }
 }
 
-impl<C: IRConstant, V: IRVariable> Substitute<C, V> for Clause<C, V> {
-    type Output = Clause<C, V>;
-    fn substitute(&self, s: &Substitution<C, V>) -> Self::Output {
+impl Substitute<IRTerm> for Clause<IRTerm> {
+    type Output = Clause<IRTerm>;
+    fn substitute(&self, s: &Substitution<IRTerm>) -> Self::Output {
         Clause {
             head: self.head.substitute(s),
             body: self.body.iter().map(|t| t.substitute(s)).collect(),
@@ -151,17 +141,17 @@ impl<C: IRConstant, V: IRVariable> Substitute<C, V> for Clause<C, V> {
     }
 }
 
-impl<C: IRConstant, V: IRVariable> RenameWithSubstitution<C, V> for Clause<C, V> {
-    type Output = Clause<C, V>;
-    fn rename(&self) -> (Self::Output, Substitution<C, V>) {
-        let s: Substitution<C, V> = self
+impl RenameWithSubstitution<IRTerm> for Clause<IRTerm> {
+    type Output = Clause<IRTerm>;
+    fn rename_with_sub(&self) -> (Self::Output, Substitution<IRTerm>) {
+        let s: Substitution<IRTerm> = self
             .variables()
             .iter()
             .map(|r| {
-                [(r.clone(), Term::Variable(r.rename()))]
+                [(r.clone(), r.rename())]
                     .iter()
                     .cloned()
-                    .collect::<Substitution<C, V>>()
+                    .collect::<Substitution<IRTerm>>()
             })
             .reduce(|mut l, r| {
                 l.extend(r);
@@ -172,51 +162,49 @@ impl<C: IRConstant, V: IRVariable> RenameWithSubstitution<C, V> for Clause<C, V>
     }
 }
 
-pub fn compose_no_extend<C: IRConstant, V: IRVariable>(
-    l: &Substitution<C, V>,
-    r: &Substitution<C, V>,
-) -> Substitution<C, V> {
-    let mut result = HashMap::<V, Term<C, V>>::new();
+pub fn compose_no_extend(
+    l: &Substitution<IRTerm>,
+    r: &Substitution<IRTerm>,
+) -> Substitution<IRTerm> {
+    let mut result = Substitution::<IRTerm>::new();
     for (k, v) in l {
         result.insert(k.clone(), v.substitute(r));
     }
     result
 }
 
-pub fn compose_extend<C: IRConstant, V: IRVariable>(
-    l: &Substitution<C, V>,
-    r: &Substitution<C, V>,
-) -> Substitution<C, V> {
+pub fn compose_extend(l: &Substitution<IRTerm>, r: &Substitution<IRTerm>) -> Substitution<IRTerm> {
     let mut result = compose_no_extend(l, r);
     result.extend(r.clone());
     result
 }
 
-impl<C: IRConstant, V: IRVariable> Literal<C, V> {
-    pub fn unify(&self, other: &Literal<C, V>) -> Option<Substitution<C, V>> {
+impl Literal<IRTerm> {
+    pub fn unify(&self, other: &Literal<IRTerm>) -> Option<Substitution<IRTerm>> {
         if self.signature() != other.signature() {
             return None;
         }
-        let mut s = HashMap::<V, Term<C, V>>::new();
+        let mut s = Substitution::<IRTerm>::new();
         for (i, self_term) in self.args.iter().enumerate() {
             let other_term = &other.args[i];
             let self_term_subs = self_term.substitute(&s);
             let other_term_subs = other_term.substitute(&s);
             if self_term_subs != other_term_subs {
-                match self_term_subs {
-                    Term::Variable(v) => {
-                        let mut upd = HashMap::<V, Term<C, V>>::new();
-                        upd.insert(v.clone(), other_term_subs.clone());
+                match (self_term_subs.clone(), other_term_subs.clone()) {
+                    // cannot unify if they are both different constants
+                    (IRTerm::Constant(_), IRTerm::Constant(_)) => return None,
+
+                    (IRTerm::Constant(_), v) => {
+                        let mut upd = Substitution::<IRTerm>::new();
+                        upd.insert(v.clone(), self_term_subs.clone());
                         s = compose_extend(&s, &upd);
                     }
-                    _ => match other_term_subs {
-                        Term::Variable(v) => {
-                            let mut upd = HashMap::<V, Term<C, V>>::new();
-                            upd.insert(v.clone(), self_term_subs.clone());
-                            s = compose_extend(&s, &upd);
-                        }
-                        _ => return None,
-                    },
+
+                    (v1, v2) => {
+                        let mut upd = Substitution::<IRTerm>::new();
+                        upd.insert(v1.clone(), v2.clone());
+                        s = compose_extend(&s, &upd);
+                    }
                 }
             }
         }
@@ -230,8 +218,8 @@ mod tests {
 
     #[test]
     fn simple_unifier() {
-        let l: logic::toy::Literal = "a(X, c)".parse().unwrap();
-        let m: logic::toy::Literal = "a(d, Y)".parse().unwrap();
+        let l: logic::Literal = "a(X, \"c\")".parse().unwrap();
+        let m: logic::Literal = "a(\"d\", Y)".parse().unwrap();
         let result = l.unify(&m);
         assert!(result.is_some());
         let mgu = result.unwrap();
@@ -240,41 +228,50 @@ mod tests {
 
     #[test]
     fn complex_unifier() {
-        let l: logic::toy::Literal = "p(Y, Y, V, W)".parse().unwrap();
-        let m: logic::toy::Literal = "p(X, Z, a, U)".parse().unwrap();
+        let l: logic::Literal = "p(Y, Y, V, W)".parse().unwrap();
+        let m: logic::Literal = "p(X, Z, \"a\", U)".parse().unwrap();
         let result = l.unify(&m);
         assert!(result.is_some());
         let mgu = result.unwrap();
         assert_eq!(l.substitute(&mgu), m.substitute(&mgu));
-        assert_eq!(mgu.get("Y".into()), Some(&Term::Variable("Z".into())));
-        assert_eq!(mgu.get("X".into()), Some(&Term::Variable("Z".into())));
         assert_eq!(
-            mgu.get("V".into()),
-            Some(&Term::Constant(Predicate("a".into())))
+            mgu.get(&logic::IRTerm::UserVariable("Y".into())),
+            Some(&logic::IRTerm::UserVariable("Z".into()))
         );
-        assert_eq!(mgu.get("W".into()), Some(&Term::Variable("U".into())));
+        assert_eq!(
+            mgu.get(&logic::IRTerm::UserVariable("X".into())),
+            Some(&logic::IRTerm::UserVariable("Z".into()))
+        );
+        assert_eq!(
+            mgu.get(&logic::IRTerm::UserVariable("V".into())),
+            Some(&logic::IRTerm::Constant("a".into()))
+        );
+        assert_eq!(
+            mgu.get(&logic::IRTerm::UserVariable("W".into())),
+            Some(&logic::IRTerm::UserVariable("U".into()))
+        );
     }
 
     #[test]
     fn simple_non_unifiable() {
-        let l: logic::toy::Literal = "a(X, b)".parse().unwrap();
-        let m: logic::toy::Literal = "a(Y)".parse().unwrap();
+        let l: logic::Literal = "a(X, \"b\")".parse().unwrap();
+        let m: logic::Literal = "a(Y)".parse().unwrap();
         let result = l.unify(&m);
         assert!(result.is_none());
     }
 
     #[test]
     fn complex_non_unifiable() {
-        let l: logic::toy::Literal = "q(X, a, X, b)".parse().unwrap();
-        let m: logic::toy::Literal = "q(Y, a, a, Y)".parse().unwrap();
+        let l: logic::Literal = "q(X, \"a\", X, \"b\")".parse().unwrap();
+        let m: logic::Literal = "q(Y, \"a\", \"a\", Y)".parse().unwrap();
         let result = l.unify(&m);
         assert!(result.is_none());
     }
 
     #[test]
     fn simple_renaming() {
-        let l: logic::toy::Literal = "a(X, X, Y)".parse().unwrap();
-        let (m, _) = l.rename();
+        let l: logic::Literal = "a(X, X, Y)".parse().unwrap();
+        let (m, _) = l.rename_with_sub();
         assert!(l != m);
         assert!(m.args[0] == m.args[1]);
         assert!(m.args[0] != m.args[2]);

--- a/src/wellformed.rs
+++ b/src/wellformed.rs
@@ -17,25 +17,25 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::logic::{Clause, IRConstant, IRVariable, Signature, Term};
+use crate::logic::{Clause, IRTerm, Signature};
 
 /// infer image predicates, i.e. those that transitively depend on image/1
 /// check that image predicates depend on image/1 in each disjunct
-pub fn check_image_predicates<C: IRConstant, V: IRVariable>(
-    clauses: &Vec<Clause<C, V>>,
+pub fn check_image_predicates(
+    clauses: &Vec<Clause<IRTerm>>,
 ) -> Result<HashSet<Signature>, HashSet<Signature>> {
     todo!()
 }
 
 // infer grounded variables, check if grounded variables are grounded in each rule
 //TODO: not sure what to do if there are variables inside compound terms
-pub fn check_grounded_variables<C: IRConstant, V: IRVariable>(
-    clauses: &Vec<Clause<C, V>>,
+pub fn check_grounded_variables(
+    clauses: &Vec<Clause<IRTerm>>,
 ) -> Result<HashMap<Signature, Vec<bool>>, HashSet<Signature>> {
     let mut errors: HashSet<Signature> = HashSet::new();
     let mut result: HashMap<Signature, Vec<bool>> = HashMap::new();
 
-    fn infer<C: IRConstant, V: IRVariable>(c: &Clause<C, V>) -> Vec<bool> {
+    fn infer(c: &Clause<IRTerm>) -> Vec<bool> {
         let body_vars = c
             .body
             .iter()
@@ -49,8 +49,8 @@ pub fn check_grounded_variables<C: IRConstant, V: IRVariable>(
             .args
             .iter()
             .map(|t| match t {
-                Term::Variable(v) => body_vars.contains(v),
-                _ => true,
+                IRTerm::Constant(_) => true,
+                v => body_vars.contains(v),
             })
             .collect()
     }
@@ -78,12 +78,11 @@ pub fn check_grounded_variables<C: IRConstant, V: IRVariable>(
 
 #[cfg(test)]
 mod tests {
-    use crate::logic::{toy, Predicate};
-
     use super::*;
+    use crate::logic::Predicate;
     #[test]
     fn consistently_grounded() {
-        let clauses: Vec<toy::Clause> = vec![
+        let clauses: Vec<Clause> = vec![
             "a(X, Y) :- b(X), c(X, Z).".parse().unwrap(),
             "a(X, Y) :- d(X).".parse().unwrap(),
             "b(X) :- d(X).".parse().unwrap(),
@@ -98,7 +97,7 @@ mod tests {
 
     #[test]
     fn inconsistently_grounded() {
-        let clauses: Vec<toy::Clause> = vec![
+        let clauses: Vec<Clause> = vec![
             "a(X, Y) :- b(X), c(X, Z).".parse().unwrap(),
             "a(X, Y) :- d(Y).".parse().unwrap(),
         ];


### PR DESCRIPTION
Related to #32.

This replaces much of the `<C, V>` generics and removes the toy language entirely. I've replaced the tests written in the toy with the IR language.

The structures are generally generic over a term `T`, but most of the implementation now assumes a concrete value for the term, that is, `IRTerm`.