### PR TITLE
Use `VerboseError` to print syntax errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "modus"
 path = "src/main.rs"
 
 [dependencies]
-nom = { version = "6", features = ["regexp"] }
+nom = { version = "7" }
 clap = "2.33.3"
 lazy_static = "1.4.0"
 fp-core = "0.1.9"

--- a/src/dockerfile.rs
+++ b/src/dockerfile.rs
@@ -210,6 +210,8 @@ where
 }
 
 pub mod parser {
+    use crate::logic::parser::IResult;
+
     use super::*;
 
     use nom::{
@@ -219,7 +221,6 @@ pub mod parser {
         combinator::{eof, map, opt, peek, recognize, value},
         multi::{many0, many1, separated_list1},
         sequence::{delimited, pair, preceded, terminated, tuple},
-        IResult,
     };
 
     //TODO: need to double-check

--- a/src/logic.rs
+++ b/src/logic.rs
@@ -218,11 +218,14 @@ pub mod parser {
         branch::alt,
         bytes::complete::tag,
         character::complete::{alpha1, alphanumeric1, one_of},
-        combinator::{map, opt, recognize, value},
+        combinator::{cut, map, opt, recognize, value},
+        error::VerboseError,
         multi::{many0, separated_list0, separated_list1},
         sequence::{delimited, pair, preceded, separated_pair, terminated},
-        IResult,
     };
+
+    /// Redeclaration that uses VerboseError instead of the default nom::Error.
+    pub type IResult<T, O> = nom::IResult<T, O, VerboseError<T>>;
 
     fn space(i: &str) -> IResult<&str, ()> {
         value(

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,11 @@ fn main() {
                     Err(e) => println!("{}", e),
                 },
                 (Err(error), _) => {
-                    println!("Didn't parse {} successfully, error: {}", input_file, error)
+                    println!(
+                        "❌ Did not parse {} successfully. Error trace:\n{}",
+                        input_file.purple(),
+                        error
+                    )
                 }
             }
         }


### PR DESCRIPTION
Related to #40 and #32.

Example of an error message before this change:
```
Didn't parse examples/Modusfile successfully, error: Parsing Error: Error { input: "python(python_version, \"ubuntu\", distr_version) :-\n    # Below we use a format string to vary which version of ubuntu we use.\n    # This makes image tags easier to work with.\n    from(f\"ubuntu:${distr_version}\")\n    # comments are allowed after an expression's comma\n    ,\n    run(f\"apt-get install -y python${python_version}\"). # comments are allowed here\n", code: Eof }
```

Example of error message after:
![image](https://user-images.githubusercontent.com/46009390/141825801-6397f281-1f99-4eaf-a1f4-d315de3cc2af.png)

This leverages nom's existing functionality. Notably I've inserted `context` to state which combinator was attempting to parse (e.g. "modus_clause") and `cut` to define scenarios where the parser cannot proceed. This means it does not read through the entire rest of the file like in the previous error.

This does mean we take more of a panic approach atm. 