### PR TITLE
JSON output changes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ use codespan_reporting::{
     },
 };
 use colored::Colorize;
-use std::{fs, path::Path};
+use std::{ffi::OsStr, fs, path::Path};
 use std::{io::Write, path::PathBuf};
 
 use modusfile::Modusfile;
@@ -121,8 +121,13 @@ fn main() {
                     Arg::with_name("JSON_OUTPUT")
                         .value_name("FILE")
                         .required(false)
-                        .long("json-out")
-                        .help("Write a JSON file"),
+                        .min_values(0)
+                        .max_values(1)
+                        .require_equals(true)
+                        .long("json")
+                        .help("Output build result as JSON")
+                        .long_help("Output build result as JSON\n\
+                                    If this flag is specified without providing a file name, output is written to stdout.")
                 )
                 .arg(
                     Arg::with_name("VERBOSE")
@@ -213,10 +218,40 @@ fn main() {
                     print_build_error_and_exit(&e.to_string(), &writer);
                 }
                 Ok(image_ids) => {
-                    if let Some(json_out) = sub.value_of_os("JSON_OUTPUT") {
-                        if let Err(e) =
-                            reporting::write_build_result(json_out, &build_plan, &image_ids[..])
-                        {
+                    if sub.is_present("JSON_OUTPUT") {
+                        let json_out_name;
+                        let mut json_out_f;
+                        let mut json_out_stdout;
+                        let json_out: &mut dyn Write;
+                        if let Some(o_path) = sub.value_of_os("JSON_OUTPUT") {
+                            json_out = match std::fs::File::create(o_path) {
+                                Ok(f) => {
+                                    json_out_f = f;
+                                    &mut json_out_f
+                                }
+                                Err(e) => {
+                                    print_build_error_and_exit(
+                                        &format!(
+                                            "Unable to open {} for writing: {}.",
+                                            o_path.to_string_lossy(),
+                                            &e
+                                        ),
+                                        &writer,
+                                    );
+                                }
+                            };
+                            json_out_name = o_path;
+                        } else {
+                            json_out_stdout = std::io::stdout();
+                            json_out = &mut json_out_stdout;
+                            json_out_name = OsStr::new("stdout");
+                        }
+                        if let Err(e) = reporting::write_build_result(
+                            json_out,
+                            &json_out_name.to_string_lossy(),
+                            &build_plan,
+                            &image_ids[..],
+                        ) {
                             print_build_error_and_exit(&e, &writer);
                         }
                     }

--- a/src/reporting.rs
+++ b/src/reporting.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{fmt::Display, io::Write};
 
 use serde::Serialize;
 
@@ -38,8 +38,9 @@ pub struct Image {
     pub digest: String,
 }
 
-pub fn write_build_result<P: AsRef<Path>>(
-    json_out: P,
+pub fn write_build_result<F: Write, P: Display>(
+    mut json_out: F,
+    json_out_name: P,
     build_plan: &BuildPlan,
     image_ids: &[String],
 ) -> Result<(), String> {
@@ -61,11 +62,11 @@ pub fn write_build_result<P: AsRef<Path>>(
         })
         .collect::<Vec<_>>();
 
-    std::fs::write(
-        json_out.as_ref(),
-        serde_json::to_vec_pretty(&res).map_err(|e| format!("Serialization error: {}", e))?,
-    )
-    .map_err(|e| format!("Error writing to {}: {}", json_out.as_ref().display(), e))?;
+    json_out
+        .write_all(
+            &serde_json::to_vec_pretty(&res).map_err(|e| format!("Serialization error: {}", e))?,
+        )
+        .map_err(|e| format!("Error writing to {}: {}", json_out_name, e))?;
 
     Ok(())
 }


### PR DESCRIPTION
- Per last meeting, the output is now flattened (`{ predicate, args, digest }`)
- Rename flag from `json-out` to `json`
- Output to stdout if no file name provided (i.e. either `--json` or `--json=file.json`)