### PR TITLE
Updated Semantic Analysis

### DIFF
--- a/src/logic.rs
+++ b/src/logic.rs
@@ -309,7 +309,7 @@ pub mod parser {
     use nom::{
         branch::alt,
         bytes::complete::{tag, take_until},
-        character::complete::{alpha1, alphanumeric1, space0, multispace0},
+        character::complete::{alpha1, alphanumeric1, multispace0, space0},
         combinator::{cut, map, opt, recognize},
         error::VerboseError,
         multi::{many0, separated_list0, separated_list1},


### PR DESCRIPTION
Resolves #110.

Currently sticking with the top-down graph approach for the first release.
Note a still present limitation is:
```
a :- a.
a :- from(...).
```
Even though it would detect image kind in the second clause, for the first clause it will not be able to determine that clause is image kind. This is where a bottom-up/fixpoint approach may be better.