### PR TITLE
SemVer comparison

### DIFF
--- a/modus-lib/Cargo.toml
+++ b/modus-lib/Cargo.toml
@@ -20,6 +20,7 @@ ptree = { version = "0.4", default-features = false, features = ["petgraph", "an
 petgraph = "0.6.0"
 rand = "0.8"
 serde = "^1.0"
+semver = "1.0"
 
 [dev-dependencies]
 serial_test = "*"


### PR DESCRIPTION
The current implementation isn't very rigorous:

- The semver library doesn't allow version strings with anything other than 2 dots in it, but I think it might be convenient to allow versions like 1.0, so I'm just adding `.0` until it parses (max 2 times).
- This means that `semver_exact("1", "1.2")` is false, while `semver_exact("1.2", "1")` is true. (`semver_exact("1.2", "1.0")` is false, as expected)

Example Modusfile:
```Modusfile
need_patch(version) :- semver_lt(version, "1.0").
# needed because negation isn't merged yet.
not_need_patch(version) :- semver_geq(version, "1.0").

app(version) :-
  from("alpine"),
  run("download my app"),
  (
    need_patch(version), run("do some patch for version before 1.0");
    not_need_patch(version), run("nop")
  ),
  run("make").
```