### PR TITLE
Improved parser error reporting

### DIFF
--- a/modus-lib/Cargo.toml
+++ b/modus-lib/Cargo.toml
@@ -16,7 +16,8 @@ path = "src/lib.rs"
 
 [dependencies]
 nom = { version = "7" }
-nom_locate = "4.0.0"
+nom_locate = "4.0.0" # for the span
+nom-supreme = "0.6.0" # for the TagError and ErrorTree
 codespan-reporting = "0.11.1"
 colored = "2"
 lazy_static = "1.4.0"

--- a/modus-lib/src/dockerfile.rs
+++ b/modus-lib/src/dockerfile.rs
@@ -218,12 +218,13 @@ pub mod parser {
 
     use nom::{
         branch::alt,
-        bytes::complete::{is_not, tag, tag_no_case},
+        bytes::complete::{is_not, tag_no_case},
         character::complete::{alpha1, alphanumeric1, char, line_ending, one_of, space0, space1},
         combinator::{eof, map, opt, peek, recognize, value},
         multi::{many0, many1, separated_list1},
         sequence::{delimited, pair, preceded, terminated, tuple},
     };
+    use nom_supreme::tag::complete::tag;
 
     //TODO: need to double-check
     pub fn alias_identifier(i: &str) -> IResult<&str, &str> {
@@ -582,8 +583,8 @@ mod tests {
             tag: "7.3-53".into(),
         };
         assert_eq!(
-            Ok(("", i)),
-            parser::image("registry.access.redhat.com/rhel7/rhel:7.3-53")
+            ("", i),
+            parser::image("registry.access.redhat.com/rhel7/rhel:7.3-53").unwrap()
         );
     }
 
@@ -595,6 +596,6 @@ mod tests {
             repo: "r".into(),
             tag: "".into(),
         };
-        assert_eq!(Ok(("", i)), parser::image("a/b/c/r"));
+        assert_eq!(("", i), parser::image("a/b/c/r").unwrap());
     }
 }

--- a/modus-lib/src/logic.rs
+++ b/modus-lib/src/logic.rs
@@ -413,19 +413,19 @@ pub mod parser {
 
     use nom::{
         branch::alt,
-        bytes::complete::{is_a, tag, take_until},
+        bytes::complete::{is_a, take_until},
         character::complete::{alpha1, alphanumeric1, multispace0},
         combinator::{cut, map, opt, recognize},
-        error::VerboseError,
         multi::{many0, many0_count, separated_list0, separated_list1},
         sequence::{delimited, pair, preceded, terminated, tuple},
         Offset, Slice,
     };
+    use nom_supreme::{error::ErrorTree, tag::complete::tag};
 
     pub type Span<'a> = LocatedSpan<&'a str>;
 
-    /// Redeclaration that uses VerboseError instead of the default nom::Error.
-    pub type IResult<T, O> = nom::IResult<T, O, VerboseError<T>>;
+    /// Redeclaration that uses ErrorTree instead of the default nom::Error.
+    pub type IResult<T, O> = nom::IResult<T, O, ErrorTree<T>>;
 
     /// Creates a parser that returns a `SpannedPosition` that spans the consumed input
     /// of a given parser. Also returns the actual output of the parser.

--- a/modus-lib/src/modusfile.rs
+++ b/modus-lib/src/modusfile.rs
@@ -771,8 +771,16 @@ pub mod parser {
         literal_identifier(i)
     }
 
-    pub fn modus_var(i: Span) -> IResult<Span, Span> {
+    fn modus_var(i: Span) -> IResult<Span, Span> {
         context(stringify!(modus_var), variable_identifier)(i)
+    }
+
+    pub fn string_interpolation(i: Span) -> IResult<Span, Span> {
+        delimited(
+            terminated(tag("${"), token_sep0),
+            modus_var,
+            cut(preceded(token_sep0, tag("}"))),
+        )(i)
     }
 
     pub fn modus_term(i: Span) -> IResult<Span, ModusTerm> {


### PR DESCRIPTION
Related to #40.

This may warrant bumping up to `v0.1.2`.

Use another nom-based library that stores a tree of failures and add a function that converts this tree to `Diagnostic` errors which should match the SLD resolution errors. The printed span should make it easier to find where the error was.

Example for this Modusfile:
![image](https://user-images.githubusercontent.com/46009390/155587651-addd45ea-b35e-407d-824a-1e5a5412fb6e.png)

Old output:
![image](https://user-images.githubusercontent.com/46009390/155583481-596b3b60-a2a3-4d35-939b-13a00a002a45.png)

New output:
![image](https://user-images.githubusercontent.com/46009390/155583542-3b74bf1b-2ec0-45b6-b741-6336252b6475.png)

In general, now all we should need are some well placed `cut`s and `context` to provide decent parse errors.