### PR TITLE
Support from("scratch")

### DIFF
--- a/modus-lib/src/transpiler.rs
+++ b/modus-lib/src/transpiler.rs
@@ -53,6 +53,12 @@ fn plan_to_docker(plan: &BuildPlan) -> ResolvedDockerfile {
             let node = &plan.nodes[node_id];
             let str_id = format!("n_{}", node_id);
             match node {
+                BuildNode::FromScratch { .. } => {
+                    vec![Instruction::From(From {
+                        parent: ResolvedParent::Image(Image::from_str("scratch").unwrap()),
+                        alias: Some(str_id),
+                    })]
+                }
                 BuildNode::From {
                     image_ref,
                     display_name: _,

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -120,3 +120,40 @@ class TestSimple(ModusTestCase):
     def test_run_failure(self):
         mf = """a :- from("alpine"), run("exit 1")."""
         self.build(mf, "a", should_succeed=False)
+
+    def test_from_scratch_nothing(self):
+        mf = """a :- from("scratch")."""
+        self.build(mf, "a")
+
+    # For the following two tests, we use an alpine image as our final image, as
+    # read_file need a shell and cat.
+
+    def test_from_scratch_copy(self):
+        mf = dedent("""\
+            a :- from("scratch"),
+                 (
+                     from("alpine"),
+                     run("echo content > /aa")
+                 )::copy("/aa", "/aa").
+            b :- from("alpine"),
+                 a::copy("/aa", "/aa").""")
+        img = self.build(mf, "b")[Fact("b", ())]
+        self.assertEqual(img.read_file("/aa"), "content\n")
+
+        # just make sure we can actually output a if we wanted to.
+        self.build(mf, "a")
+
+    def test_from_scratch_property(self):
+        mf = dedent("""\
+            a :- from("scratch")::set_workdir("/tmp"),
+                 (
+                     from("alpine"),
+                     run("echo content > /aa")
+                 )::copy("/aa", "aa").
+            b :- from("alpine"),
+                 a::copy("/tmp/aa", "/tmp/aa").""")
+        img = self.build(mf, "b")[Fact("b", ())]
+        self.assertEqual(img.read_file("/tmp/aa"), "content\n")
+
+        # just make sure we can actually output a if we wanted to.
+        self.build(mf, "a")


### PR DESCRIPTION
This basically treats `from("scratch")` as any other image in order to simplify buildkit-frontend logic. buildkit.rs will "resolve" those by building the following Dockerfile:
```Dockerfile
FROM scratch
```
and the frontend would use `Source::image(id)`, where `id` is the empty image just built.

The alternative is to use [`buildkit_llb::ops::exec::Mount::Scratch`](https://docs.rs/buildkit-llb/latest/buildkit_llb/ops/exec/enum.Mount.html#variant.Scratch) whenever the parent is `from("scratch")`, but with this approach, due to the limit of the buildkit_llb rust library, it is not possible to output `from("scratch")` as the final image.

Note that, also due to bad library design, [`resolve_image_config`](https://docs.rs/buildkit-frontend/latest/buildkit_frontend/struct.Bridge.html#method.resolve_image_config) will fail when the image is empty. This is worked-around by treating FromScratch specially.