### PR TITLE
EXPORT_CONCURRENCY: default to num_cpus

### DIFF
--- a/modus/Cargo.toml
+++ b/modus/Cargo.toml
@@ -30,6 +30,7 @@ thiserror = "1.0"
 ptree = { version = "0.4", default-features = false, features = ["petgraph", "ansi", "value"] } # pretty-print trees
 petgraph = "0.6.0"
 codespan-reporting = "0.11.1"
+num_cpus = "1.13.1"
 
 # For buildkit
 buildkit-frontend = "0.3.0"


### PR DESCRIPTION
No reason to hard-code something like 8, and we have just discussed on teams that this is likely mostly checksum computation.