### PR TITLE
Clears cmd when setting entrypoint

### DIFF
--- a/modus/src/buildkit_frontend.rs
+++ b/modus/src/buildkit_frontend.rs
@@ -372,10 +372,11 @@ async fn handle_build_plan(
             } => {
                 let (p_out, p_conf) = translated_nodes[*parent].clone().unwrap();
                 let mut p_conf = (*p_conf).clone();
-                p_conf
+                let img_conf = p_conf
                     .config
-                    .get_or_insert_with(empty_image_config)
-                    .entrypoint = Some(new_entrypoint.to_owned());
+                    .get_or_insert_with(empty_image_config);
+                img_conf.entrypoint = Some(new_entrypoint.to_owned());
+                img_conf.cmd = None;
                 (p_out, Arc::new(p_conf))
             }
             SetLabel {


### PR DESCRIPTION
This is required so that experiment result image runs correctly.

---

According to https://docs.docker.com/engine/reference/builder/#entrypoint:

> If CMD is defined from the base image, setting ENTRYPOINT will reset CMD to an empty value. In this scenario, CMD must be defined in the current image to have a value.

Note that Dockerfile allow defining CMD and ENTRYPOINT in any order, so CMD ["hello"]; ENTRYPOINT "echo" will actually set both the CMD and ENTRYPOINT so that the result is running echo hello. To simplify matter here we always reset cmd for now (we don't even have ::set_cmd yet).