### PR TITLE
Fix f-string anonymous variables and negation translation

### DIFF
--- a/modus-lib/Cargo.toml
+++ b/modus-lib/Cargo.toml
@@ -25,6 +25,7 @@ fp-core = "0.1.9"
 dot = "0.1.4" # graphviz library
 thiserror = "1.0"
 ptree = { version = "0.4", default-features = false, features = ["petgraph", "ansi", "value"] } # pretty-print trees
+itertools = "0.10.3"
 petgraph = "0.6.0"
 rand = "0.8"
 serde = "^1.0"

--- a/modus-lib/src/modusfile.rs
+++ b/modus-lib/src/modusfile.rs
@@ -253,7 +253,7 @@ impl ModusTerm {
                 })
                 .collect(),
             ModusTerm::UserVariable(s) => vec![s],
-            ModusTerm::List(_, _) => todo!(),
+            ModusTerm::List(_, ts) => ts.iter().flat_map(ModusTerm::variable_strings).collect(),
             ModusTerm::Constant(_) | ModusTerm::AnonymousVariable => Vec::new(),
         }
     }

--- a/test/test_solver.py
+++ b/test/test_solver.py
@@ -150,7 +150,7 @@ class TestSolver(ModusTestCase):
 
     def test_supports_f_strings_with_anonymous_variables(self):
         md = dedent("""\
-            foo(version) :- version != f"5.${_}".
+            foo(version) :- version != f"5.${_}", from("ubuntu").
         """)
 
         self.build(md, 'foo("5.1")', should_succeed=False)

--- a/test/test_solver.py
+++ b/test/test_solver.py
@@ -148,6 +148,16 @@ class TestSolver(ModusTestCase):
         self.assertEqual(len(images), 1)
         self.assertIn(Fact("my_app", ("alpine:3.15",)), images)
 
+    def test_supports_f_strings_with_anonymous_variables(self):
+        md = dedent("""\
+            foo(version) :- version != f"5.${_}".
+        """)
+
+        self.build(md, 'foo("5.1")', should_succeed=False)
+        images = self.build(md, 'foo("1.1")', should_succeed=True)
+        self.assertEqual(len(images), 1)
+        self.assertIn(Fact("foo", ("1.1",)), images)
+
     def test_enforces_stratification(self):
         md = dedent("""\
             foo(X) :- bar(X).


### PR DESCRIPTION
Fixes #163 and #197.

- Adds `InterpolatedAnonymousVariable` so there is a convenient way to determine if an interpolated variable is anonymous.
- Properly treat these as anonymous variables when translating.
- Replace negated _literals_ with a new rule, like previously done for expressions. This is needed since the constraints added by the format string was previously 'outside' the negation, which often doesn't work due to groundness requirements.