### PR TITLE
`--explain` output improvements

### DIFF
--- a/modus-lib/src/modusfile.rs
+++ b/modus-lib/src/modusfile.rs
@@ -753,7 +753,7 @@ pub mod parser {
         map(
             pair(
                 many0_count(terminated(nom::character::complete::char('!'), token_sep0)),
-                delimited(l_paren_with_comments, body, r_paren_with_comments),
+                delimited(l_paren_with_comments, cut(body), r_paren_with_comments),
             ),
             |(neg_count, expr)| {
                 if neg_count % 2 == 0 {


### PR DESCRIPTION
Experimenting with some alternative output format.
Also resolves #199.

Features:
- Sequential `string_concat` converted to displayed as f-string.
- Lay out the new goals from a resolution on different lines, for readability.
- Omit successful builtin resolution - this wouldn't add any useful information when debugging.

Example of `--explain` output where the user has made a typo in their variable name.
![image](https://user-images.githubusercontent.com/46009390/162003083-761d4519-59cf-4a73-b053-14dd4c5e0faa.png)
