### PR TITLE
More concise error output

### DIFF
--- a/modus-lib/src/logic.rs
+++ b/modus-lib/src/logic.rs
@@ -189,6 +189,16 @@ impl IRTerm {
     pub fn is_anonymous_variable(&self) -> bool {
         matches!(self, Self::AnonymousVariable(..))
     }
+
+    pub fn normalized(&self) -> IRTerm {
+        match self {
+            IRTerm::AuxiliaryVariable(_) => IRTerm::AuxiliaryVariable(0),
+            IRTerm::RenamedVariable(_, _) => self.get_original().normalized(),
+            IRTerm::AnonymousVariable(_) => IRTerm::AnonymousVariable(0),
+            IRTerm::List(l) => IRTerm::List(l.iter().map(|x| x.normalized()).collect()),
+            c => c.clone(),
+        }
+    }
 }
 
 /// Structure that holds information about the position of some section of the source code.
@@ -319,6 +329,14 @@ impl Literal {
         Literal {
             positive: !self.positive,
             ..self.clone()
+        }
+    }
+
+    /// Returns a copy of the literal with the terms normalized.
+    pub fn normalized_terms(self) -> Literal {
+        Literal {
+            args: self.args.iter().map(|t| t.normalized()).collect(),
+            ..self
         }
     }
 }

--- a/modus-lib/src/logic.rs
+++ b/modus-lib/src/logic.rs
@@ -189,16 +189,6 @@ impl IRTerm {
     pub fn is_anonymous_variable(&self) -> bool {
         matches!(self, Self::AnonymousVariable(..))
     }
-
-    pub fn normalized(&self) -> IRTerm {
-        match self {
-            IRTerm::AuxiliaryVariable(_) => IRTerm::AuxiliaryVariable(0),
-            IRTerm::RenamedVariable(_, _) => self.get_original().normalized(),
-            IRTerm::AnonymousVariable(_) => IRTerm::AnonymousVariable(0),
-            IRTerm::List(l) => IRTerm::List(l.iter().map(|x| x.normalized()).collect()),
-            c => c.clone(),
-        }
-    }
 }
 
 /// Structure that holds information about the position of some section of the source code.
@@ -332,10 +322,11 @@ impl Literal {
         }
     }
 
-    /// Returns a copy of the literal with the terms normalized.
+    /// Returns a copy of the literal with the terms 'normalized'.
+    /// Currently this means just getting the original terms for any renamed terms.
     pub fn normalized_terms(self) -> Literal {
         Literal {
-            args: self.args.iter().map(|t| t.normalized()).collect(),
+            args: self.args.iter().map(|t| t.get_original().clone()).collect(),
             ..self
         }
     }

--- a/modus-lib/src/sld.rs
+++ b/modus-lib/src/sld.rs
@@ -600,8 +600,8 @@ impl fmt::Display for ResolutionError {
             ResolutionError::MaximumDepthExceeded(_, max_depth) => {
                 write!(f, "exceeded maximum depth of {}", max_depth)
             }
-            ResolutionError::BuiltinFailure(_, builtin_name) => {
-                write!(f, "builtin {} failed to apply or unify", builtin_name)
+            ResolutionError::BuiltinFailure(l, builtin_name) => {
+                write!(f, "builtin {builtin_name} failed to apply or unify: {l}")
             }
             ResolutionError::InsufficientRules(literal) => write!(
                 f,

--- a/modus-lib/src/sld.rs
+++ b/modus-lib/src/sld.rs
@@ -253,7 +253,8 @@ impl Tree {
                             + &xs.join(&("\n".to_owned() + &" ".repeat(depth * 3) + &"- "))
                     } else {
                         "".to_string()
-                    }.bright_red()
+                    }
+                    .bright_red()
                 ));
             } else {
                 let mut resolvent_pairs = t.resolvents().into_iter().collect::<Vec<_>>();
@@ -714,13 +715,28 @@ impl ResolutionError {
     /// auxiliary variable index.
     fn normalize(self) -> ResolutionError {
         match self {
-            ResolutionError::UnknownPredicate(l) => ResolutionError::UnknownPredicate(l.normalized_terms()),
-            ResolutionError::InsufficientGroundness(ls) => ResolutionError::InsufficientGroundness(ls.into_iter().map(|x| x.normalized_terms()).collect()),
-            ResolutionError::MaximumDepthExceeded(ls, s) => ResolutionError::MaximumDepthExceeded(ls.into_iter().map(|x| x.normalized_terms()).collect(), s),
-            ResolutionError::BuiltinFailure(l, s) => ResolutionError::BuiltinFailure(l.normalized_terms(), s),
-            ResolutionError::InsufficientRules(l) => ResolutionError::InsufficientRules(l.normalized_terms()),
-            ResolutionError::InconsistentGroundnessSignature(sigs) => ResolutionError::InconsistentGroundnessSignature(sigs.to_vec()),
-            ResolutionError::NegationProof(l) => ResolutionError::NegationProof(l.normalized_terms()),
+            ResolutionError::UnknownPredicate(l) => {
+                ResolutionError::UnknownPredicate(l.normalized_terms())
+            }
+            ResolutionError::InsufficientGroundness(ls) => ResolutionError::InsufficientGroundness(
+                ls.into_iter().map(|x| x.normalized_terms()).collect(),
+            ),
+            ResolutionError::MaximumDepthExceeded(ls, s) => ResolutionError::MaximumDepthExceeded(
+                ls.into_iter().map(|x| x.normalized_terms()).collect(),
+                s,
+            ),
+            ResolutionError::BuiltinFailure(l, s) => {
+                ResolutionError::BuiltinFailure(l.normalized_terms(), s)
+            }
+            ResolutionError::InsufficientRules(l) => {
+                ResolutionError::InsufficientRules(l.normalized_terms())
+            }
+            ResolutionError::InconsistentGroundnessSignature(sigs) => {
+                ResolutionError::InconsistentGroundnessSignature(sigs.to_vec())
+            }
+            ResolutionError::NegationProof(l) => {
+                ResolutionError::NegationProof(l.normalized_terms())
+            }
         }
     }
 }


### PR DESCRIPTION
This converts renamed variables in literals to their original when creating the final error type, so errors that are only different w.r.t. renaming index are considered the same and not printed separately.