### PR TITLE
Use severity to determine if SLD tree succeeded

### DIFF
--- a/modus-lib/src/logic.rs
+++ b/modus-lib/src/logic.rs
@@ -189,6 +189,16 @@ impl IRTerm {
     pub fn is_anonymous_variable(&self) -> bool {
         matches!(self, Self::AnonymousVariable(..))
     }
+
+    pub fn normalized(&self) -> IRTerm {
+        match self {
+            IRTerm::AuxiliaryVariable(_) => IRTerm::AuxiliaryVariable(0),
+            IRTerm::RenamedVariable(_, _) => self.get_original().normalized(),
+            IRTerm::AnonymousVariable(_) => IRTerm::AnonymousVariable(0),
+            IRTerm::List(l) => IRTerm::List(l.iter().map(|x| x.normalized()).collect()),
+            c => c.clone(),
+        }
+    }
 }
 
 /// Structure that holds information about the position of some section of the source code.
@@ -319,6 +329,14 @@ impl Literal {
         Literal {
             positive: !self.positive,
             ..self.clone()
+        }
+    }
+
+    /// Returns a copy of the literal with the terms normalized.
+    pub fn normalized_terms(self) -> Literal {
+        Literal {
+            args: self.args.iter().map(|t| t.normalized()).collect(),
+            ..self
         }
     }
 }

--- a/modus-lib/src/logic.rs
+++ b/modus-lib/src/logic.rs
@@ -189,16 +189,6 @@ impl IRTerm {
     pub fn is_anonymous_variable(&self) -> bool {
         matches!(self, Self::AnonymousVariable(..))
     }
-
-    pub fn normalized(&self) -> IRTerm {
-        match self {
-            IRTerm::AuxiliaryVariable(_) => IRTerm::AuxiliaryVariable(0),
-            IRTerm::RenamedVariable(_, _) => self.get_original().normalized(),
-            IRTerm::AnonymousVariable(_) => IRTerm::AnonymousVariable(0),
-            IRTerm::List(l) => IRTerm::List(l.iter().map(|x| x.normalized()).collect()),
-            c => c.clone(),
-        }
-    }
 }
 
 /// Structure that holds information about the position of some section of the source code.
@@ -332,10 +322,11 @@ impl Literal {
         }
     }
 
-    /// Returns a copy of the literal with the terms normalized.
+    /// Returns a copy of the literal with the terms 'normalized'.
+    /// Currently this means just getting the original terms for any renamed terms.
     pub fn normalized_terms(self) -> Literal {
         Literal {
-            args: self.args.iter().map(|t| t.normalized()).collect(),
+            args: self.args.iter().map(|t| t.get_original().clone()).collect(),
             ..self
         }
     }

--- a/modus-lib/src/sld.rs
+++ b/modus-lib/src/sld.rs
@@ -600,8 +600,8 @@ impl fmt::Display for ResolutionError {
             ResolutionError::MaximumDepthExceeded(_, max_depth) => {
                 write!(f, "exceeded maximum depth of {}", max_depth)
             }
-            ResolutionError::BuiltinFailure(_, builtin_name) => {
-                write!(f, "builtin {} failed to apply or unify", builtin_name)
+            ResolutionError::BuiltinFailure(l, builtin_name) => {
+                write!(f, "builtin {builtin_name} failed to apply or unify: {l}")
             }
             ResolutionError::InsufficientRules(literal) => write!(
                 f,

--- a/modus-lib/src/sld.rs
+++ b/modus-lib/src/sld.rs
@@ -253,7 +253,8 @@ impl Tree {
                             + &xs.join(&("\n".to_owned() + &" ".repeat(depth * 3) + &"- "))
                     } else {
                         "".to_string()
-                    }.bright_red()
+                    }
+                    .bright_red()
                 ));
             } else {
                 let mut resolvent_pairs = t.resolvents().into_iter().collect::<Vec<_>>();
@@ -714,13 +715,28 @@ impl ResolutionError {
     /// auxiliary variable index.
     fn normalize(self) -> ResolutionError {
         match self {
-            ResolutionError::UnknownPredicate(l) => ResolutionError::UnknownPredicate(l.normalized_terms()),
-            ResolutionError::InsufficientGroundness(ls) => ResolutionError::InsufficientGroundness(ls.into_iter().map(|x| x.normalized_terms()).collect()),
-            ResolutionError::MaximumDepthExceeded(ls, s) => ResolutionError::MaximumDepthExceeded(ls.into_iter().map(|x| x.normalized_terms()).collect(), s),
-            ResolutionError::BuiltinFailure(l, s) => ResolutionError::BuiltinFailure(l.normalized_terms(), s),
-            ResolutionError::InsufficientRules(l) => ResolutionError::InsufficientRules(l.normalized_terms()),
-            ResolutionError::InconsistentGroundnessSignature(sigs) => ResolutionError::InconsistentGroundnessSignature(sigs.to_vec()),
-            ResolutionError::NegationProof(l) => ResolutionError::NegationProof(l.normalized_terms()),
+            ResolutionError::UnknownPredicate(l) => {
+                ResolutionError::UnknownPredicate(l.normalized_terms())
+            }
+            ResolutionError::InsufficientGroundness(ls) => ResolutionError::InsufficientGroundness(
+                ls.into_iter().map(|x| x.normalized_terms()).collect(),
+            ),
+            ResolutionError::MaximumDepthExceeded(ls, s) => ResolutionError::MaximumDepthExceeded(
+                ls.into_iter().map(|x| x.normalized_terms()).collect(),
+                s,
+            ),
+            ResolutionError::BuiltinFailure(l, s) => {
+                ResolutionError::BuiltinFailure(l.normalized_terms(), s)
+            }
+            ResolutionError::InsufficientRules(l) => {
+                ResolutionError::InsufficientRules(l.normalized_terms())
+            }
+            ResolutionError::InconsistentGroundnessSignature(sigs) => {
+                ResolutionError::InconsistentGroundnessSignature(sigs.to_vec())
+            }
+            ResolutionError::NegationProof(l) => {
+                ResolutionError::NegationProof(l.normalized_terms())
+            }
         }
     }
 }

--- a/modus-lib/src/sld.rs
+++ b/modus-lib/src/sld.rs
@@ -981,20 +981,24 @@ pub fn sld(
 
         let mut success_resolvents = HashMap::new();
         let mut fail_resolvents = HashMap::new();
-        // FIXME: use alternative success
-        if sld_res.tree.is_success() {
+
+        // the negation proof should also fail if there is an error in the subtree
+        let subtree_error = sld_res.tree.contains_error_severity();
+        if sld_res.tree.is_success() || subtree_error {
             if store_full_tree {
                 fail_resolvents.insert((lid, rid), (mgu, renaming, sld_res.tree));
             }
 
             let err = ResolutionError::NegationProof(l.literal);
-            errs.insert(err.clone());
+            if !subtree_error {
+                errs.insert(err.clone());
+            }
             let tree = Tree {
                 goal: goal.to_owned(),
                 level,
                 success_resolvents,
                 fail_resolvents,
-                error: Some(err),
+                error: if subtree_error { None } else { Some(err) },
             };
 
             return SLDResult { tree, errors: errs };

--- a/modus-lib/src/sld.rs
+++ b/modus-lib/src/sld.rs
@@ -712,7 +712,7 @@ impl ResolutionError {
 
     /// Returns a normalized version of a resolution error --- should be better for hash equality.
     /// Without this, may get a lot of resolution errors, for example, that are identical except for a different
-    /// auxiliary variable index.
+    /// renamed variable index.
     fn normalize(self) -> ResolutionError {
         match self {
             ResolutionError::UnknownPredicate(l) => {

--- a/modus-lib/src/sld.rs
+++ b/modus-lib/src/sld.rs
@@ -631,7 +631,7 @@ impl ResolutionError {
     fn severity(&self) -> Severity {
         match self {
             ResolutionError::UnknownPredicate(_) => Severity::Error,
-            ResolutionError::InsufficientGroundness(_) => Severity::Warning,
+            ResolutionError::InsufficientGroundness(_) => Severity::Error,
             ResolutionError::MaximumDepthExceeded(_, _) => Severity::Warning,
             ResolutionError::BuiltinFailure(_, _) => Severity::Warning,
             ResolutionError::InsufficientRules(_) => Severity::Warning,

--- a/modus-lib/src/sld.rs
+++ b/modus-lib/src/sld.rs
@@ -146,7 +146,7 @@ impl Tree {
             if t.error.is_some() || t.resolvents().len() != 1 {
                 t
             } else {
-                traverse_stack(&t.resolvents().iter().next().unwrap().1.2)
+                traverse_stack(&t.resolvents().iter().next().unwrap().1 .2)
             }
         }
 
@@ -684,13 +684,12 @@ impl ResolutionError {
             ResolutionError::BuiltinFailure(l, builtin_name) => {
                 format!("{builtin_name} failed")
             }
-            ResolutionError::InsufficientRules(literal) => format!(
-                "failed to resolve: {}",
-                literal
-            ),
-            ResolutionError::InconsistentGroundnessSignature(_) => format!(
-                "clauses with inconsistent signatures",
-            ),
+            ResolutionError::InsufficientRules(literal) => {
+                format!("failed to resolve: {}", literal)
+            }
+            ResolutionError::InconsistentGroundnessSignature(_) => {
+                format!("clauses with inconsistent signatures",)
+            }
             ResolutionError::NegationProof(lit) => {
                 format!("proof found for {}", lit.negated())
             }

--- a/modus/src/main.rs
+++ b/modus/src/main.rs
@@ -544,18 +544,13 @@ fn main() {
                                         .expect("error when printing");
                                 }
                             }
-                            Err(e) => {
-                                for diag_error in e.iter().filter(|diag_error| {
-                                    diag_error.severity
-                                        <= codespan_reporting::diagnostic::Severity::Warning
-                                }) {
-                                    term::emit(&mut err_writer.lock(), &config, &file, &diag_error)
-                                        .expect("Error when printing to stderr.")
-                                }
-                                for diag_error in e.iter().filter(|diag_error| {
-                                    diag_error.severity
-                                        >= codespan_reporting::diagnostic::Severity::Error
-                                }) {
+                            Err(mut e) => {
+                                e.sort_by(|a, b| {
+                                    a.severity
+                                        .partial_cmp(&b.severity)
+                                        .unwrap_or(a.code.cmp(&b.code))
+                                });
+                                for diag_error in &e {
                                     term::emit(&mut err_writer.lock(), &config, &file, &diag_error)
                                         .expect("Error when printing to stderr.")
                                 }

--- a/modus/src/main.rs
+++ b/modus/src/main.rs
@@ -545,7 +545,17 @@ fn main() {
                                 }
                             }
                             Err(e) => {
-                                for diag_error in e {
+                                for diag_error in e.iter().filter(|diag_error| {
+                                    diag_error.severity
+                                        <= codespan_reporting::diagnostic::Severity::Warning
+                                }) {
+                                    term::emit(&mut err_writer.lock(), &config, &file, &diag_error)
+                                        .expect("Error when printing to stderr.")
+                                }
+                                for diag_error in e.iter().filter(|diag_error| {
+                                    diag_error.severity
+                                        >= codespan_reporting::diagnostic::Severity::Error
+                                }) {
                                     term::emit(&mut err_writer.lock(), &config, &file, &diag_error)
                                         .expect("Error when printing to stderr.")
                                 }


### PR DESCRIPTION
Miscellaneous final changes relevant to my report.
Takes into account the severity of errors encountered during resolution to determine a successful tree. This ensures important errors are not silently dropped.